### PR TITLE
Missing reference in Transparent Compiler

### DIFF
--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1488,6 +1488,7 @@ let CheckOneInputWithCallback
     : Cancellable<Finisher<NodeToTypeCheck, TcState, PartialResult>> =
     cancellable {
         try
+            printfn "About to type-check %A" node
             CheckSimulateException tcConfig
 
             let m = input.Range

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -98,6 +98,7 @@
       <Link>PrettyNaming.fs</Link>
     </Compile>
     <Compile Include="TooltipTests.fs" />
+    <Compile Include="TransparentTests.fs" />
     <Compile Include="..\service\Program.fs">
       <Link>Program.fs</Link>
     </Compile>

--- a/tests/FSharp.Compiler.Service.Tests/TransparentTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/TransparentTests.fs
@@ -1,0 +1,99 @@
+﻿module FSharp.Compiler.Service.Tests.TransparentTests
+
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Text
+open NUnit.Framework
+
+// The goal of this test is to raise awareness of how the Transparent Compiler should be behave when only the dependent files are being type-checked.
+
+[<Test>]
+let ``Establish link`` () =
+    let checker = FSharpChecker.Create(useTransparentCompiler = true)
+
+    let args = mkProjectCommandLineArgsSilent ("Project.dll", Array.empty)
+
+    // In the sample project we have two files who are not linked to each other initially.
+    let options =
+        { checker.GetProjectOptionsFromCommandLineArgs("Project.fsproj", args) with
+            SourceFiles = [| "A.fs"; "B.fs" |] }
+
+    let content_Of_A =
+        """
+module Project.A
+
+type X =
+    {
+        Y : int
+    }
+"""
+
+    let content_Of_B_V1 =
+        """
+module Project.B
+
+let meh _ = ()
+"""
+
+    // We start to edit the second file and hope to use a type from the first file.
+    let content_Of_B_V2 =
+        """
+module Project.B
+
+let meh _ : X = ()
+"""
+
+    let getFileSnapShot useV1 _ fileName =
+        async {
+            return
+                { FileName = fileName
+                  Version = if useV1 || fileName <> "B.fs" then "1" else "2"
+                  GetSource =
+                    fun () ->
+                        task {
+                            match fileName with
+                            | "A.fs" -> return SourceText.ofString content_Of_A
+                            | "B.fs" -> return SourceText.ofString (if useV1 then content_Of_B_V1 else content_Of_B_V2)
+                            | _ -> return failwithf $"No source for %s{fileName}"
+                        } }
+        }
+
+    let projectSnapShot_Initial =
+        FSharpProjectSnapshot.FromOptions(options, getFileSnapShot true)
+        |> Async.RunImmediate
+
+    let unwrapCheckResult (_, checkResult) =
+        match checkResult with
+        | FSharpCheckFileAnswer.Aborted -> failwith "aborted"
+        | FSharpCheckFileAnswer.Succeeded checkFileResults -> checkFileResults
+
+    let initialCheckResult =
+        checker.ParseAndCheckFileInProject("B.fs", projectSnapShot_Initial)
+        |> Async.RunImmediate
+        |> unwrapCheckResult
+
+    Assert.True(Array.isEmpty initialCheckResult.Diagnostics)
+
+    // Now we start to edit the second file and introduce an unresolved type
+
+    let projectSnapShot_Subsequent =
+        FSharpProjectSnapshot.FromOptions(options, getFileSnapShot false)
+        |> Async.RunImmediate
+
+    let subsequentCheckResult =
+        checker.ParseAndCheckFileInProject("B.fs", projectSnapShot_Subsequent)
+        |> Async.RunImmediate
+        |> unwrapCheckResult
+
+    // After the second checker.ParseAndCheckFileInProject
+    // CheckOneInputWithCallback will still not have been called for A.fs
+    // This is understandable, as no link was established via the AST in both cases.
+
+    // This leads to `  B.fs(3, 13): [FS0039] The type 'X' is not defined.`
+    // And my main question is how editor will resolve the missing 'X' via an editor light bulb-like action?
+    // I don't know how the different editors deal with this today, but there might be a chance that they rely on all the files being type-checked.
+    // If this is the case, we should discuss this with the community.
+    let diagnostic =
+        subsequentCheckResult.Diagnostics
+        |> Array.find (fun diag -> diag.ErrorNumber = 39)
+
+    ()


### PR DESCRIPTION
> Transparent Compiler, a morning's play,
Parsing, checking, a code-fixing fray.
Editors ponder and wonder to type-check all files?
A conversation sparked, and implications riled.

Hi all,

I played around this morning with the 'Transparent Compiler' and I really like where this is going!

Praise aside, I found an interesting scenario I wish to discuss.
When `checker.ParseAndCheckFileInProject` is called, the Transparent Compiler will type-check the file and all the dependencies. This works out nicely but gets into a grey area when you start to edit the code where you are no longer in a valid state.

Please first read `tests/FSharp.Compiler.Service.Tests/TransparentTests.fs`!

My question is about how the different editors will deal with this kind of code fix:
![Screenshot 2023-06-30 131217](https://github.com/0101/fsharp/assets/2621499/f6bbc7c3-0248-4d8b-a6be-655d7c5094be)

As mentioned in the unit test, the editor might rely on the fact that all files are type-checked (as is the case in the present-day situation), while currently, in the Transparent Compiler (at the time of writing), this is not the case.

Some questions to ponder over:
- When `checker.ParseAndCheckFileInProject` is called, should each file up to the requested file be type-checked or are we happy with the more performant-only type-check the dependent files?
- If we only check the dependent files, should we expose the untyped information from all the other files? 

Internally in `DependencyResolution.mkGraph` we construct a `Trie` with more or less the information we are after. type `X` in the unit test can easily be pinpointed to `Project.A` after we processed all the AST. We don't exactly have this today, but I can see it is quite feasible to capture.

Tagging a bunch of people: @auduchinok, @dedsec256, @0101, @psfinaki, @baronfel, @theangrybyrd, @safesparrow, @dawedawe. Please tag others if I missed anyone.

Let us know what the implications would be right now for the editor you work on.

PS: There are no intentions to merge this PR. It only exists to kick off the conversation.
